### PR TITLE
refactored build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,81 @@
+# Ignore macOS system files
+.DS_Store
+
+# Ignore Xcode-specific files
+*.xcworkspace
+*.xcuserdata/
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/**/*
+.idea/
+
+# Ignore build products
+build/
+DerivedData/
+*.app
+*.dSYM
+*.ipa
+*.xcarchive
+*.o
+*.a
+*.dylib
+*.framework
+
+# Ignore intermediate build files and cache
+*.obj
+*.pdb
+*.ilk
+*.pch
+*.tmp
+*.log
+*.swp
+*.lock
+*.moved-aside
+*.old
+*.bak
+*.cache
+*.pyc
+*.class
+
+# Ignore Makefile build outputs
+*.d
+*.out
+*.so
+*.elf
+*.map
+*.lst
+*.hex
+*.bin
+*.tar.gz
+
+# Ignore version control for pods
+Pods/
+Carthage/
+
+# Ignore C/C++ artifacts
+*.gch
+*.gcda
+*.gcno
+*.gcov
+*.lo
+*.la
+
+# Ignore archives and generated files
+*.zip
+*.tar
+*.7z
+
+# Ignore node_modules in case of embedded React Native or similar
+node_modules/
+
+# Ignore configuration files
+*.plist
+*.xcconfig
+
+# Ignore IDE files
+*.iml
+.idea/
+.vscode/
+
+# Finale Hacks directory
+Finale Hacks/

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,27 @@
-
 INSTALL_DIR = /Library/Application\ Support/MakeMusic/Finale\ 27/Plug-ins
 
-all:
-	mkdir -p 'Finale Hacks/Finale Hacks.bundle/Contents/MacOS'
-	cc -dynamiclib -arch x86_64 -arch arm64 -o 'Finale Hacks/Finale Hacks.bundle/Contents/MacOS/Finale Hacks' FinaleHacks.m -framework Foundation
-	cp Info.plist 'Finale Hacks/Finale Hacks.bundle/Contents'
+BUILD_DIR = Finale\ Hacks
+RELEASE_DIR = ${BUILD_DIR}/Release
+DEBUG_DIR = ${BUILD_DIR}/Debug
+BUNDLE_DIR = Finale\ Hacks.bundle/Contents
 
-install:
+CXX = c++  # Use the C++ compiler
+CXXFLAGS = -std=c++17 -mmacosx-version-min=10.10 -dynamiclib -framework Foundation -x objective-c++
+ARCH_FLAGS = -arch x86_64 -arch arm64
+
+all:
+	mkdir -p ${RELEASE_DIR}/${BUNDLE_DIR}/MacOS
+	${CXX} ${CXXFLAGS} ${ARCH_FLAGS} -o ${RELEASE_DIR}/${BUNDLE_DIR}/MacOS/'Finale Hacks' src/FinaleHacks.m
+	cp Info.plist ${RELEASE_DIR}/${BUNDLE_DIR}
+
+install: all
 	rm -rf ${INSTALL_DIR}/Finale\ Hacks
-	cp -r 'Finale Hacks' ${INSTALL_DIR}
+	cp -r ${RELEASE_DIR} ${INSTALL_DIR}/Finale\ Hacks
+
+debug:
+	mkdir -p ${DEBUG_DIR}/${BUNDLE_DIR}/MacOS
+	${CXX} ${CXXFLAGS} -g -O0 ${ARCH_FLAGS} -o ${DEBUG_DIR}/${BUNDLE_DIR}/MacOS/'Finale Hacks' src/FinaleHacks.m
+	cp Info.plist ${DEBUG_DIR}/${BUNDLE_DIR}
 
 clean:
 	rm -rf 'Finale Hacks'

--- a/README.md
+++ b/README.md
@@ -1,11 +1,18 @@
 # Finale Hacks
 
-Finale Hacks is a custom plug-in for MakeMusic Finale 27 (and possibly earlier versions, but no guarantees) that
-patches their code to work around known bugs.
+Finale Hacks is a custom plug-in for MakeMusic Finale 27 running on macOS that patches their code to work around known bugs and issues. It should also work in Finale 25 and Finale 26, but these are not supported.
 
 Please file bugs with the correct tag.  For problems where the plug-in fails to fix a bug that it claims to fix,
 file under Plug-in Bug.  For new bugs in Finale that you'd like someone to try to work around, file under
 Finale Bug.
+
+## Dependencies
+
+To build this project, you need the XCode Command Line Tools. These can be obtained by opening a Terminal window and typing:
+
+```bash
+xcode-select --install
+```
 
 ## Installing
 
@@ -15,7 +22,7 @@ To install the workaround:
 - make
 - make install
 
-Although this will probably work in some earlier versions, it has been tested only in Finale 27.
+Although this will probably work in some earlier versions (back to Finale 25), it has been tested only in Finale 27.
 
 You can see that the hack is loaded correctly by running
 
@@ -28,6 +35,56 @@ on the command line and looking for log messages similar to the following:
 
 Hope this helps!
 
+## Debugging With Visual Studio Code
+
+1. Install the following extensions:
+   - C/C++ (from Microsoft)
+   - C/C++ Extension Pack (from Microsoft)
+   - C/C++ Themes (from Microsoft)
+   - codeLLDB (from Vadim Chugunov)
+2. Add the following `.vscode/launch.json` file:
+
+```json
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Finale Hacks in Finale",
+            "type": "lldb",
+            "request": "launch",
+            "program": "/Applications/Finale.app/Contents/MacOS/Finale",
+            "args": [],
+            "cwd": "${workspaceFolder}",
+            "env": {
+                "DYLD_INSERT_LIBRARIES": "${workspaceFolder}/Finale Hacks/Debug/Finale Hacks.bundle/Contents/MacOS/Finale Hacks"
+            },
+            "preLaunchTask": "build-debug"
+        }
+    ]
+}
+```
+
+3. Add the following `.vscode/tasks.json` file:
+
+```json
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build-debug",
+            "type": "shell",
+            "command": "make",
+            "args": ["debug"],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
+}
+```
+
+Now you should be able to launch Finale and debug the project from the project home directory.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Hope this helps!
 
 ## Debugging With Visual Studio Code
 
+NOTE: It is recommended to remove the release version of the plugin from Finale's plugin directory while debugging.
+
 1. Install the following extensions:
    - C/C++ (from Microsoft)
    - C/C++ Extension Pack (from Microsoft)
@@ -84,7 +86,7 @@ Hope this helps!
 }
 ```
 
-Now you should be able to launch Finale and debug the project from the project home directory.
+Now you should be able to debug `Finale Hacks` from the top-level `Finale Hacks` directory. VS Code automatically launches Finale and stops at your breakpoints as you reach them.
 
 ---
 

--- a/src/FinaleHacks.m
+++ b/src/FinaleHacks.m
@@ -10,11 +10,28 @@
 
 + (void)load {
   NSLog(@"Hacking Finale to work around bugs.");
+
   id MusViewClass = objc_getClass("MusView");
+  if (!MusViewClass) {
+    NSLog(@"Finale Hacks Error: MusView class not found. Skipping hack installation.");
+    return;
+  }
+
   Method displayMethod = class_getInstanceMethod(MusViewClass, @selector(display));
+  if (!displayMethod) {
+    NSLog(@"Finale Hacks Error: Failed to retrieve display selector for MusView class. Skipping hack installation.");
+    return;
+  }
+
   IMP originalImplementation = method_getImplementation(displayMethod);
+  if (!originalImplementation) {
+    NSLog(@"Finale Hacks Error: Failed to get the implementation of display method. Skipping hack installation.");
+    return;
+  }
+
   IMP newImplementation = imp_implementationWithBlock(^(id blockSelf) {
     if (objc_getAssociatedObject(blockSelf, @selector(display))) {
+      NSLog(@"Finale Hacks disabled recursive call to MusView display selector.");
       return;
     }
 
@@ -25,7 +42,9 @@
 
     objc_setAssociatedObject(blockSelf, @selector(display), nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
   });
+
   method_setImplementation(displayMethod, newImplementation);
+  
   NSLog(@"Done hacking Finale to work around bugs.");
 }
 


### PR DESCRIPTION
Resolves #1

- Refactored `FinaleHacks.m` into `src/FinaleHacks.m`.
- Added error checking to `FinaleHacks.m`.
- Refactored MakeFile.
   - Use c++ compiler
   - Set minimum version to macOS 10.10 (i.e., most permissive)
   - Added `debug` step for debugging
   - Release and Debug are now directed to separate folders within the `Finale Hacks` build target directory.

These are preliminary steps. With your approval, I will start refactoring the source code to facilitate the addition of further hacks in a modular manner, and the step after that will be to add my own. I'm thinking it is better to offer these in bite-sized chunks.

@dgatwood 